### PR TITLE
Add support for the small, large and dynamic viewport size units

### DIFF
--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -13,11 +13,11 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class Size extends PrimitiveValue
 {
     /**
-     * vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
+     * vh/vw/vm(ax)/vmin/rem/svh/lvh/dvh/svw/lvw/dvw are absolute insofar as they don’t scale to the immediate parent (only the viewport)
      *
      * @var array<int, string>
      */
-    const ABSOLUTE_SIZE_UNITS = ['px', 'cm', 'mm', 'mozmm', 'in', 'pt', 'pc', 'vh', 'vw', 'vmin', 'vmax', 'rem'];
+    const ABSOLUTE_SIZE_UNITS = ['px', 'cm', 'mm', 'mozmm', 'in', 'pt', 'pc', 'vh', 'vw', 'vmin', 'vmax', 'svh', 'lvh', 'dvh', 'svw', 'lvw', 'dvw', 'rem'];
 
     /**
      * @var array<int, string>


### PR DESCRIPTION
This PR adds support for the small, large and dynamic viewport size units: `svh`, `lvh`, `dvh`, `svw`, `lvw`, `dvw`.

Since currently there is no support for those units, they cannot be properly parsed which results in an incorrect output: `height: 80dvh` becomes `height: 80 dvh`.

More information on the units: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units
